### PR TITLE
Add FixMatch backend skeleton with JWT and basic endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,16 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+            <version>0.9.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/src/main/java/com/example/fixmatch/config/OpenApiConfig.java
+++ b/src/main/java/com/example/fixmatch/config/OpenApiConfig.java
@@ -1,0 +1,15 @@
+package com.example.fixmatch.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI api() {
+        return new OpenAPI().info(new Info().title("FixMatch API").version("1.0"));
+    }
+}

--- a/src/main/java/com/example/fixmatch/config/SecurityConfig.java
+++ b/src/main/java/com/example/fixmatch/config/SecurityConfig.java
@@ -1,0 +1,60 @@
+package com.example.fixmatch.config;
+
+import com.example.fixmatch.security.CustomUserDetailsService;
+import com.example.fixmatch.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtFilter;
+    private final CustomUserDetailsService userDetailsService;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .cors(cors -> {})
+            .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/auth/**", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll()
+                .anyRequest().authenticated())
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public org.springframework.web.cors.CorsConfigurationSource corsConfigurationSource() {
+        var configuration = new org.springframework.web.cors.CorsConfiguration();
+        configuration.addAllowedOriginPattern("*");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedHeader("*");
+        configuration.setAllowCredentials(true);
+        var source = new org.springframework.web.cors.UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/com/example/fixmatch/controller/AuthController.java
+++ b/src/main/java/com/example/fixmatch/controller/AuthController.java
@@ -1,0 +1,39 @@
+package com.example.fixmatch.controller;
+
+import com.example.fixmatch.dto.*;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.security.JwtTokenProvider;
+import com.example.fixmatch.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider tokenProvider;
+
+    @PostMapping("/register")
+    public ResponseEntity<?> register(@RequestBody RegisterRequest request) {
+        User user = userService.register(request);
+        String token = tokenProvider.generateToken(user.getEmail());
+        return ResponseEntity.ok(new AuthResponse(token));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequest request) {
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword()));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        String token = tokenProvider.generateToken(request.getEmail());
+        return ResponseEntity.ok(new AuthResponse(token));
+    }
+}

--- a/src/main/java/com/example/fixmatch/controller/CertificateController.java
+++ b/src/main/java/com/example/fixmatch/controller/CertificateController.java
@@ -1,0 +1,37 @@
+package com.example.fixmatch.controller;
+
+import com.example.fixmatch.dto.CertificateRequest;
+import com.example.fixmatch.entity.Certificate;
+import com.example.fixmatch.entity.Role;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.service.CertificateService;
+import com.example.fixmatch.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequestMapping("/certificates")
+@RequiredArgsConstructor
+public class CertificateController {
+
+    private final CertificateService certificateService;
+    private final UserService userService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('SPECIALIST')")
+    public ResponseEntity<Certificate> upload(@RequestBody CertificateRequest request, Principal principal) {
+        User user = userService.findByEmail(principal.getName()).orElseThrow();
+        return ResponseEntity.ok(certificateService.upload(request, user));
+    }
+
+    @GetMapping("/mine")
+    public ResponseEntity<List<Certificate>> mine(Principal principal) {
+        User user = userService.findByEmail(principal.getName()).orElseThrow();
+        return ResponseEntity.ok(certificateService.myCertificates(user));
+    }
+}

--- a/src/main/java/com/example/fixmatch/controller/JobController.java
+++ b/src/main/java/com/example/fixmatch/controller/JobController.java
@@ -1,0 +1,36 @@
+package com.example.fixmatch.controller;
+
+import com.example.fixmatch.dto.JobRequest;
+import com.example.fixmatch.entity.Job;
+import com.example.fixmatch.entity.Role;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.service.JobService;
+import com.example.fixmatch.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequestMapping("/jobs")
+@RequiredArgsConstructor
+public class JobController {
+
+    private final JobService jobService;
+    private final UserService userService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('CLIENT')")
+    public ResponseEntity<Job> create(@RequestBody JobRequest request, Principal principal) {
+        User user = userService.findByEmail(principal.getName()).orElseThrow();
+        return ResponseEntity.ok(jobService.create(request, user));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Job>> list() {
+        return ResponseEntity.ok(jobService.listAll());
+    }
+}

--- a/src/main/java/com/example/fixmatch/controller/MatchController.java
+++ b/src/main/java/com/example/fixmatch/controller/MatchController.java
@@ -1,0 +1,39 @@
+package com.example.fixmatch.controller;
+
+import com.example.fixmatch.dto.MatchLikeRequest;
+import com.example.fixmatch.entity.Job;
+import com.example.fixmatch.entity.Match;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.service.JobService;
+import com.example.fixmatch.service.MatchService;
+import com.example.fixmatch.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequestMapping("/match")
+@RequiredArgsConstructor
+public class MatchController {
+
+    private final MatchService matchService;
+    private final JobService jobService;
+    private final UserService userService;
+
+    @PostMapping("/like")
+    public ResponseEntity<Match> like(@RequestBody MatchLikeRequest request, Principal principal) {
+        User user = userService.findByEmail(principal.getName()).orElseThrow();
+        Job job = jobService.findById(request.getJobId());
+        User specialist = userService.findById(request.getSpecialistId()).orElseThrow();
+        return ResponseEntity.ok(matchService.like(request, job, specialist));
+    }
+
+    @GetMapping("/matches")
+    public ResponseEntity<List<Match>> myMatches(Principal principal) {
+        User specialist = userService.findByEmail(principal.getName()).orElseThrow();
+        return ResponseEntity.ok(matchService.matchesForSpecialist(specialist));
+    }
+}

--- a/src/main/java/com/example/fixmatch/controller/MessageController.java
+++ b/src/main/java/com/example/fixmatch/controller/MessageController.java
@@ -1,0 +1,36 @@
+package com.example.fixmatch.controller;
+
+import com.example.fixmatch.dto.MessageRequest;
+import com.example.fixmatch.entity.Message;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.service.MessageService;
+import com.example.fixmatch.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequestMapping("/messages")
+@RequiredArgsConstructor
+public class MessageController {
+
+    private final MessageService messageService;
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<Message> send(@RequestBody MessageRequest request, Principal principal) {
+        User sender = userService.findByEmail(principal.getName()).orElseThrow();
+        User receiver = userService.findById(request.getReceiverId()).orElseThrow();
+        return ResponseEntity.ok(messageService.send(request, sender, receiver));
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<Message>> chat(@PathVariable Long userId, Principal principal) {
+        User sender = userService.findByEmail(principal.getName()).orElseThrow();
+        User receiver = userService.findById(userId).orElseThrow();
+        return ResponseEntity.ok(messageService.getChat(sender, receiver));
+    }
+}

--- a/src/main/java/com/example/fixmatch/dto/AuthResponse.java
+++ b/src/main/java/com/example/fixmatch/dto/AuthResponse.java
@@ -1,0 +1,10 @@
+package com.example.fixmatch.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AuthResponse {
+    private String token;
+}

--- a/src/main/java/com/example/fixmatch/dto/CertificateRequest.java
+++ b/src/main/java/com/example/fixmatch/dto/CertificateRequest.java
@@ -1,0 +1,9 @@
+package com.example.fixmatch.dto;
+
+import lombok.Data;
+
+@Data
+public class CertificateRequest {
+    private String type;
+    private String fileUrl;
+}

--- a/src/main/java/com/example/fixmatch/dto/JobRequest.java
+++ b/src/main/java/com/example/fixmatch/dto/JobRequest.java
@@ -1,0 +1,14 @@
+package com.example.fixmatch.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class JobRequest {
+    private String description;
+    private String category;
+    private Boolean urgency;
+    private String location;
+    private List<String> images;
+}

--- a/src/main/java/com/example/fixmatch/dto/LoginRequest.java
+++ b/src/main/java/com/example/fixmatch/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.example.fixmatch.dto;
+
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/example/fixmatch/dto/MatchLikeRequest.java
+++ b/src/main/java/com/example/fixmatch/dto/MatchLikeRequest.java
@@ -1,0 +1,11 @@
+package com.example.fixmatch.dto;
+
+import lombok.Data;
+
+@Data
+public class MatchLikeRequest {
+    private Long jobId;
+    private Long specialistId;
+    private Boolean likedByClient;
+    private Boolean likedBySpecialist;
+}

--- a/src/main/java/com/example/fixmatch/dto/MessageRequest.java
+++ b/src/main/java/com/example/fixmatch/dto/MessageRequest.java
@@ -1,0 +1,9 @@
+package com.example.fixmatch.dto;
+
+import lombok.Data;
+
+@Data
+public class MessageRequest {
+    private Long receiverId;
+    private String content;
+}

--- a/src/main/java/com/example/fixmatch/dto/RegisterRequest.java
+++ b/src/main/java/com/example/fixmatch/dto/RegisterRequest.java
@@ -1,0 +1,12 @@
+package com.example.fixmatch.dto;
+
+import com.example.fixmatch.entity.Role;
+import lombok.Data;
+
+@Data
+public class RegisterRequest {
+    private String name;
+    private String email;
+    private String password;
+    private Role role;
+}

--- a/src/main/java/com/example/fixmatch/entity/Certificate.java
+++ b/src/main/java/com/example/fixmatch/entity/Certificate.java
@@ -1,0 +1,16 @@
+package com.example.fixmatch.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+public class Certificate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String type;
+    private String fileUrl;
+    @ManyToOne
+    private User uploadedBy;
+}

--- a/src/main/java/com/example/fixmatch/entity/Job.java
+++ b/src/main/java/com/example/fixmatch/entity/Job.java
@@ -1,0 +1,21 @@
+package com.example.fixmatch.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.util.List;
+
+@Data
+@Entity
+public class Job {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String description;
+    private String category;
+    private Boolean urgency;
+    private String location;
+    @ElementCollection
+    private List<String> images;
+    @ManyToOne
+    private User createdBy;
+}

--- a/src/main/java/com/example/fixmatch/entity/Match.java
+++ b/src/main/java/com/example/fixmatch/entity/Match.java
@@ -1,0 +1,19 @@
+package com.example.fixmatch.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "matches")
+public class Match {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    private Job job;
+    @ManyToOne
+    private User specialist;
+    private Boolean likedByClient;
+    private Boolean likedBySpecialist;
+}

--- a/src/main/java/com/example/fixmatch/entity/Message.java
+++ b/src/main/java/com/example/fixmatch/entity/Message.java
@@ -1,0 +1,19 @@
+package com.example.fixmatch.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+public class Message {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    private User sender;
+    @ManyToOne
+    private User receiver;
+    private String content;
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/com/example/fixmatch/entity/Role.java
+++ b/src/main/java/com/example/fixmatch/entity/Role.java
@@ -1,0 +1,6 @@
+package com.example.fixmatch.entity;
+
+public enum Role {
+    CLIENT,
+    SPECIALIST
+}

--- a/src/main/java/com/example/fixmatch/entity/User.java
+++ b/src/main/java/com/example/fixmatch/entity/User.java
@@ -1,0 +1,20 @@
+package com.example.fixmatch.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    @Column(unique = true)
+    private String email;
+    private String password;
+    @Enumerated(EnumType.STRING)
+    private Role role;
+    private Double reputation;
+}

--- a/src/main/java/com/example/fixmatch/repository/CertificateRepository.java
+++ b/src/main/java/com/example/fixmatch/repository/CertificateRepository.java
@@ -1,0 +1,11 @@
+package com.example.fixmatch.repository;
+
+import com.example.fixmatch.entity.Certificate;
+import com.example.fixmatch.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CertificateRepository extends JpaRepository<Certificate, Long> {
+    List<Certificate> findByUploadedBy(User user);
+}

--- a/src/main/java/com/example/fixmatch/repository/JobRepository.java
+++ b/src/main/java/com/example/fixmatch/repository/JobRepository.java
@@ -1,0 +1,7 @@
+package com.example.fixmatch.repository;
+
+import com.example.fixmatch.entity.Job;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobRepository extends JpaRepository<Job, Long> {
+}

--- a/src/main/java/com/example/fixmatch/repository/MatchRepository.java
+++ b/src/main/java/com/example/fixmatch/repository/MatchRepository.java
@@ -1,0 +1,11 @@
+package com.example.fixmatch.repository;
+
+import com.example.fixmatch.entity.Match;
+import com.example.fixmatch.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MatchRepository extends JpaRepository<Match, Long> {
+    List<Match> findBySpecialist(User specialist);
+}

--- a/src/main/java/com/example/fixmatch/repository/MessageRepository.java
+++ b/src/main/java/com/example/fixmatch/repository/MessageRepository.java
@@ -1,0 +1,11 @@
+package com.example.fixmatch.repository;
+
+import com.example.fixmatch.entity.Message;
+import com.example.fixmatch.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+    List<Message> findBySenderAndReceiver(User sender, User receiver);
+}

--- a/src/main/java/com/example/fixmatch/repository/UserRepository.java
+++ b/src/main/java/com/example/fixmatch/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.example.fixmatch.repository;
+
+import com.example.fixmatch.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/example/fixmatch/security/CustomUserDetailsService.java
+++ b/src/main/java/com/example/fixmatch/security/CustomUserDetailsService.java
@@ -1,0 +1,30 @@
+package com.example.fixmatch.security;
+
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        return new org.springframework.security.core.userdetails.User(
+                user.getEmail(),
+                user.getPassword(),
+                List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
+        );
+    }
+}

--- a/src/main/java/com/example/fixmatch/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/fixmatch/security/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package com.example.fixmatch.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider tokenProvider;
+    private final CustomUserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider, CustomUserDetailsService userDetailsService) {
+        this.tokenProvider = tokenProvider;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        final String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            if (tokenProvider.validateJwt(token)) {
+                String username = tokenProvider.getUsernameFromJwt(token);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/fixmatch/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/fixmatch/security/JwtTokenProvider.java
@@ -1,0 +1,42 @@
+package com.example.fixmatch.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${app.jwt.secret:secret}")
+    private String jwtSecret;
+
+    @Value("${app.jwt.expiration:86400000}")
+    private long jwtExpirationMs;
+
+    public String generateToken(String username) {
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date((new Date()).getTime() + jwtExpirationMs))
+                .signWith(SignatureAlgorithm.HS512, jwtSecret)
+                .compact();
+    }
+
+    public String getUsernameFromJwt(String token) {
+        Claims claims = Jwts.parser().setSigningKey(jwtSecret).parseClaimsJws(token).getBody();
+        return claims.getSubject();
+    }
+
+    public boolean validateJwt(String authToken) {
+        try {
+            Jwts.parser().setSigningKey(jwtSecret).parseClaimsJws(authToken);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/example/fixmatch/service/CertificateService.java
+++ b/src/main/java/com/example/fixmatch/service/CertificateService.java
@@ -1,0 +1,28 @@
+package com.example.fixmatch.service;
+
+import com.example.fixmatch.dto.CertificateRequest;
+import com.example.fixmatch.entity.Certificate;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.repository.CertificateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CertificateService {
+    private final CertificateRepository certificateRepository;
+
+    public Certificate upload(CertificateRequest request, User user) {
+        Certificate c = new Certificate();
+        c.setType(request.getType());
+        c.setFileUrl(request.getFileUrl());
+        c.setUploadedBy(user);
+        return certificateRepository.save(c);
+    }
+
+    public List<Certificate> myCertificates(User user) {
+        return certificateRepository.findByUploadedBy(user);
+    }
+}

--- a/src/main/java/com/example/fixmatch/service/JobService.java
+++ b/src/main/java/com/example/fixmatch/service/JobService.java
@@ -1,0 +1,35 @@
+package com.example.fixmatch.service;
+
+import com.example.fixmatch.dto.JobRequest;
+import com.example.fixmatch.entity.Job;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.repository.JobRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class JobService {
+    private final JobRepository jobRepository;
+
+    public Job create(JobRequest request, User user) {
+        Job job = new Job();
+        job.setDescription(request.getDescription());
+        job.setCategory(request.getCategory());
+        job.setUrgency(request.getUrgency());
+        job.setLocation(request.getLocation());
+        job.setImages(request.getImages());
+        job.setCreatedBy(user);
+        return jobRepository.save(job);
+    }
+
+    public List<Job> listAll() {
+        return jobRepository.findAll();
+    }
+
+    public Job findById(Long id) {
+        return jobRepository.findById(id).orElse(null);
+    }
+}

--- a/src/main/java/com/example/fixmatch/service/MatchService.java
+++ b/src/main/java/com/example/fixmatch/service/MatchService.java
@@ -1,0 +1,30 @@
+package com.example.fixmatch.service;
+
+import com.example.fixmatch.dto.MatchLikeRequest;
+import com.example.fixmatch.entity.Job;
+import com.example.fixmatch.entity.Match;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.repository.MatchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MatchService {
+    private final MatchRepository matchRepository;
+
+    public Match like(MatchLikeRequest request, Job job, User specialist) {
+        Match match = new Match();
+        match.setJob(job);
+        match.setSpecialist(specialist);
+        match.setLikedByClient(request.getLikedByClient());
+        match.setLikedBySpecialist(request.getLikedBySpecialist());
+        return matchRepository.save(match);
+    }
+
+    public List<Match> matchesForSpecialist(User specialist) {
+        return matchRepository.findBySpecialist(specialist);
+    }
+}

--- a/src/main/java/com/example/fixmatch/service/MessageService.java
+++ b/src/main/java/com/example/fixmatch/service/MessageService.java
@@ -1,0 +1,30 @@
+package com.example.fixmatch.service;
+
+import com.example.fixmatch.dto.MessageRequest;
+import com.example.fixmatch.entity.Message;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.repository.MessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+    private final MessageRepository messageRepository;
+
+    public Message send(MessageRequest request, User sender, User receiver) {
+        Message m = new Message();
+        m.setSender(sender);
+        m.setReceiver(receiver);
+        m.setContent(request.getContent());
+        m.setTimestamp(LocalDateTime.now());
+        return messageRepository.save(m);
+    }
+
+    public List<Message> getChat(User sender, User receiver) {
+        return messageRepository.findBySenderAndReceiver(sender, receiver);
+    }
+}

--- a/src/main/java/com/example/fixmatch/service/UserService.java
+++ b/src/main/java/com/example/fixmatch/service/UserService.java
@@ -1,0 +1,36 @@
+package com.example.fixmatch.service;
+
+import com.example.fixmatch.dto.LoginRequest;
+import com.example.fixmatch.dto.RegisterRequest;
+import com.example.fixmatch.entity.Role;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public User register(RegisterRequest request) {
+        User user = new User();
+        user.setName(request.getName());
+        user.setEmail(request.getEmail());
+        user.setPassword(passwordEncoder.encode(request.getPassword()));
+        user.setRole(Optional.ofNullable(request.getRole()).orElse(Role.CLIENT));
+        return userRepository.save(user);
+    }
+
+    public Optional<User> findByEmail(String email) {
+        return userRepository.findByEmail(email);
+    }
+
+    public Optional<User> findById(Long id) {
+        return userRepository.findById(id);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=FixMatch
+spring.datasource.url=jdbc:mysql://localhost:3306/fixmatch
+spring.datasource.username=YOUR_DB_USER
+spring.datasource.password=YOUR_DB_PASSWORD
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
+app.jwt.secret=your_jwt_secret
+app.jwt.expiration=86400000


### PR DESCRIPTION
This pull request introduces significant enhancements to the `FixMatch` application by adding security, API documentation, and new features for job management, user authentication, and messaging. The changes include new dependencies, configurations, controllers, DTOs, and entity classes. Below is a breakdown of the most important changes:

### Dependency and Configuration Additions

* **Dependencies in `pom.xml`:** Added `jjwt` for JWT-based authentication and `springdoc-openapi-starter-webmvc-ui` for API documentation support.
* **OpenAPI Configuration:** Introduced `OpenApiConfig` to configure OpenAPI documentation with a basic API title and version.
* **Security Configuration:** Added `SecurityConfig` to handle JWT-based authentication, method-level security, and CORS configuration. It includes a `SecurityFilterChain` and beans for `AuthenticationManager` and `PasswordEncoder`.

### Controller Implementations

* **Authentication (`AuthController`):** Added endpoints for user registration and login, utilizing JWT for token generation and authentication.
* **Job Management (`JobController`):** Added endpoints for job creation (restricted to clients) and listing all jobs.
* **Certificate Management (`CertificateController`):** Added endpoints for uploading certificates (restricted to specialists) and retrieving a user's certificates.
* **Matching (`MatchController`):** Added endpoints for liking matches and retrieving matches for specialists.
* **Messaging (`MessageController`):** Added endpoints for sending messages between users and retrieving chat history.

### DTO and Entity Additions

* **DTOs:** Introduced request and response DTOs for authentication (`AuthResponse`, `RegisterRequest`, `LoginRequest`), job management (`JobRequest`), certificate management (`CertificateRequest`), matching (`MatchLikeRequest`), and messaging (`MessageRequest`). [[1]](diffhunk://#diff-34c89bc3b8959909bcd30e37c0ca911c47b978afd85fe2d961bb90889deddd18R1-R10) [[2]](diffhunk://#diff-6f9335cc9f275f4acc1677650b4568e9062388289a561231a3ed8d2f1f62a337R1-R9) [[3]](diffhunk://#diff-ef48e2120d8c501e6e89c2b2fe27b29481dd3755756b27126d50b211fc36d1edR1-R14) [[4]](diffhunk://#diff-02c3b084bfd0c82e51b3ac908e742407277852fdb1b484383786ad3079dc3081R1-R9) [[5]](diffhunk://#diff-6a686d4eb93105c5822d7fe45c5c763050cf0d0a429e9ed86f9b4566e03a5b3eR1-R11) [[6]](diffhunk://#diff-b329be05127105e6f63fe641d15e5806e5b4e370c5917a671e99f94dd6b0f3afR1-R9) [[7]](diffhunk://#diff-5ae8651a5c93422ffd215063dc4bb3d0382fe6fcddb0852be5dba1f18ed16ca0R1-R12)
* **Entities:** Added entity classes for `Certificate`, `Job`, `Match`, `Message`, and `Role` to represent the application's core domain models. These include relationships (e.g., `@ManyToOne`) and attributes for persistence. [[1]](diffhunk://#diff-045c631c291f7396a6969920444203b8afe811512cf343d563bb02c928fa3f63R1-R16) [[2]](diffhunk://#diff-a140d7b27533a83c71f8d5253f512648b0f0224f415d549a53b370c849b98da7R1-R21) [[3]](diffhunk://#diff-11b663b14ff9d358186604ab5b4ed83c16d2eaab44a124c6d88d20f786d7ca00R1-R19) [[4]](diffhunk://#diff-8dfe2b7b4a6d8616c0a59f0a9a8ba0a60295caecf2182690b0cb6175d3f33e6cR1-R19) [[5]](diffhunk://#diff-5e3d8707c640644b539b18b21f946585dbe001422c8fa765b9a4a79359cfdee6R1-R6)