### PR TITLE
Add integration tests for JWT endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/com/example/fixmatch/integration/JwtIntegrationTest.java
+++ b/src/test/java/com/example/fixmatch/integration/JwtIntegrationTest.java
@@ -1,0 +1,66 @@
+package com.example.fixmatch.integration;
+
+import com.example.fixmatch.dto.AuthResponse;
+import com.example.fixmatch.dto.LoginRequest;
+import com.example.fixmatch.dto.RegisterRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class JwtIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void registerLoginAndAccessJobs() throws Exception {
+        RegisterRequest register = new RegisterRequest();
+        register.setName("Test User");
+        register.setEmail("user@example.com");
+        register.setPassword("password");
+
+        mockMvc.perform(post("/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(register)))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail("user@example.com");
+        login.setPassword("password");
+
+        String loginResponse = mockMvc.perform(post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        AuthResponse auth = objectMapper.readValue(loginResponse, AuthResponse.class);
+        String bearerToken = "Bearer " + auth.getToken();
+
+        mockMvc.perform(get("/jobs"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/jobs")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer invalid"))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/jobs")
+                .header(HttpHeaders.AUTHORIZATION, bearerToken))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+app.jwt.secret=testsecret


### PR DESCRIPTION
## Summary
- create integration test covering register, login and authenticated access to /jobs
- add H2 database config for tests
- include H2 dependency for test profile

## Testing
- `./mvnw test -q` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68493092d1b483309258899a78294206