### PR TITLE
Add endpoints for users, requests and projects

### DIFF
--- a/src/main/java/com/example/fixmatch/config/SecurityConfig.java
+++ b/src/main/java/com/example/fixmatch/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
             .cors(cors -> {})
             .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/auth/**", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll()
+                .requestMatchers("/auth/**", "/api/usuarios", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll()
                 .anyRequest().authenticated())
             .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/com/example/fixmatch/controller/ProyectoController.java
+++ b/src/main/java/com/example/fixmatch/controller/ProyectoController.java
@@ -1,0 +1,37 @@
+package com.example.fixmatch.controller;
+
+import com.example.fixmatch.dto.IdResponse;
+import com.example.fixmatch.dto.ProyectoRequest;
+import com.example.fixmatch.entity.Proyecto;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.service.ProyectoService;
+import com.example.fixmatch.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/proyectos")
+@RequiredArgsConstructor
+public class ProyectoController {
+    private final ProyectoService proyectoService;
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<IdResponse> create(@RequestBody ProyectoRequest request) {
+        User user = userService.findById(request.getUsuarioId()).orElseThrow();
+        Proyecto p = proyectoService.create(request, user);
+        return ResponseEntity.ok(new IdResponse(p.getId()));
+    }
+
+    @PostMapping("/fotos")
+    public ResponseEntity<?> uploadFotos(@RequestParam Long projectId, @RequestParam("fotos") MultipartFile[] fotos) throws IOException {
+        for (MultipartFile foto : fotos) {
+            proyectoService.addFoto(projectId, foto);
+        }
+        return ResponseEntity.ok().body("ok");
+    }
+}

--- a/src/main/java/com/example/fixmatch/controller/SolicitudController.java
+++ b/src/main/java/com/example/fixmatch/controller/SolicitudController.java
@@ -1,0 +1,37 @@
+package com.example.fixmatch.controller;
+
+import com.example.fixmatch.dto.IdResponse;
+import com.example.fixmatch.dto.SolicitudRequest;
+import com.example.fixmatch.entity.Solicitud;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.service.SolicitudService;
+import com.example.fixmatch.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/solicitudes")
+@RequiredArgsConstructor
+public class SolicitudController {
+    private final SolicitudService solicitudService;
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<IdResponse> create(@RequestBody SolicitudRequest request) {
+        User user = userService.findById(request.getUsuarioId()).orElseThrow();
+        Solicitud s = solicitudService.create(request, user);
+        return ResponseEntity.ok(new IdResponse(s.getId()));
+    }
+
+    @PostMapping("/fotos")
+    public ResponseEntity<?> uploadFotos(@RequestParam Long solicitudId, @RequestParam("fotos") MultipartFile[] fotos) throws IOException {
+        for (MultipartFile foto : fotos) {
+            solicitudService.addFoto(solicitudId, foto);
+        }
+        return ResponseEntity.ok().body("ok");
+    }
+}

--- a/src/main/java/com/example/fixmatch/controller/UsuarioController.java
+++ b/src/main/java/com/example/fixmatch/controller/UsuarioController.java
@@ -1,0 +1,32 @@
+package com.example.fixmatch.controller;
+
+import com.example.fixmatch.dto.CreateUsuarioRequest;
+import com.example.fixmatch.dto.IdResponse;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/usuarios")
+@RequiredArgsConstructor
+public class UsuarioController {
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<IdResponse> create(@RequestBody CreateUsuarioRequest request) {
+        User user = new User();
+        user.setName(request.getNombre());
+        user.setEmail(request.getEmail());
+        user.setPassword(request.getPassword()); // raw, service will encode
+        user.setRole(request.getRole());
+        user.setTelefono(request.getTelefono());
+        user.setUbicacion(request.getUbicacion());
+        if (request.getEspecialista() != null) {
+            user.setServicios(request.getEspecialista().getServicios());
+        }
+        User saved = userService.registerUser(user);
+        return ResponseEntity.ok(new IdResponse(saved.getId()));
+    }
+}

--- a/src/main/java/com/example/fixmatch/dto/CreateUsuarioRequest.java
+++ b/src/main/java/com/example/fixmatch/dto/CreateUsuarioRequest.java
@@ -1,0 +1,28 @@
+package com.example.fixmatch.dto;
+
+import com.example.fixmatch.entity.Role;
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class CreateUsuarioRequest {
+    private String tipoUsuario; // "cliente" or "especialista"
+    private String nombre;
+    private String email;
+    private String telefono;
+    private String password;
+    private String ubicacion;
+    private EspecialistaData especialista;
+
+    @Data
+    public static class EspecialistaData {
+        private List<String> servicios;
+    }
+
+    public Role getRole() {
+        if ("especialista".equalsIgnoreCase(tipoUsuario)) {
+            return Role.SPECIALIST;
+        }
+        return Role.CLIENT;
+    }
+}

--- a/src/main/java/com/example/fixmatch/dto/IdResponse.java
+++ b/src/main/java/com/example/fixmatch/dto/IdResponse.java
@@ -1,0 +1,10 @@
+package com.example.fixmatch.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class IdResponse {
+    private Long id;
+}

--- a/src/main/java/com/example/fixmatch/dto/ProyectoRequest.java
+++ b/src/main/java/com/example/fixmatch/dto/ProyectoRequest.java
@@ -1,0 +1,11 @@
+package com.example.fixmatch.dto;
+
+import lombok.Data;
+
+@Data
+public class ProyectoRequest {
+    private String nombre;
+    private String descripcion;
+    private String fecha; // YYYY-MM-DD
+    private Long usuarioId;
+}

--- a/src/main/java/com/example/fixmatch/dto/SolicitudRequest.java
+++ b/src/main/java/com/example/fixmatch/dto/SolicitudRequest.java
@@ -1,0 +1,11 @@
+package com.example.fixmatch.dto;
+
+import lombok.Data;
+
+@Data
+public class SolicitudRequest {
+    private String especialidad;
+    private String nombreSolicitud;
+    private String descripcion;
+    private Long usuarioId;
+}

--- a/src/main/java/com/example/fixmatch/entity/Proyecto.java
+++ b/src/main/java/com/example/fixmatch/entity/Proyecto.java
@@ -1,0 +1,21 @@
+package com.example.fixmatch.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@Entity
+public class Proyecto {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String nombre;
+    private String descripcion;
+    private LocalDate fecha;
+    @ManyToOne
+    private User usuario;
+    @OneToMany(mappedBy = "proyecto", cascade = CascadeType.ALL)
+    private List<ProyectoFoto> fotos;
+}

--- a/src/main/java/com/example/fixmatch/entity/ProyectoFoto.java
+++ b/src/main/java/com/example/fixmatch/entity/ProyectoFoto.java
@@ -1,0 +1,17 @@
+package com.example.fixmatch.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+public class ProyectoFoto {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String url;
+    private LocalDateTime fechaSubida;
+    @ManyToOne
+    private Proyecto proyecto;
+}

--- a/src/main/java/com/example/fixmatch/entity/Solicitud.java
+++ b/src/main/java/com/example/fixmatch/entity/Solicitud.java
@@ -1,0 +1,22 @@
+package com.example.fixmatch.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Entity
+public class Solicitud {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String especialidad;
+    private String nombreSolicitud;
+    private String descripcion;
+    private LocalDateTime fechaCreacion;
+    @ManyToOne
+    private User usuario;
+    @OneToMany(mappedBy = "solicitud", cascade = CascadeType.ALL)
+    private List<SolicitudFoto> fotos;
+}

--- a/src/main/java/com/example/fixmatch/entity/SolicitudFoto.java
+++ b/src/main/java/com/example/fixmatch/entity/SolicitudFoto.java
@@ -1,0 +1,17 @@
+package com.example.fixmatch.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+public class SolicitudFoto {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String url;
+    private LocalDateTime fechaSubida;
+    @ManyToOne
+    private Solicitud solicitud;
+}

--- a/src/main/java/com/example/fixmatch/entity/User.java
+++ b/src/main/java/com/example/fixmatch/entity/User.java
@@ -2,6 +2,7 @@ package com.example.fixmatch.entity;
 
 import jakarta.persistence.*;
 import lombok.Data;
+import java.util.List;
 
 @Data
 @Entity
@@ -17,4 +18,8 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Role role;
     private Double reputation;
+    private String telefono;
+    private String ubicacion;
+    @ElementCollection
+    private List<String> servicios;
 }

--- a/src/main/java/com/example/fixmatch/repository/ProyectoFotoRepository.java
+++ b/src/main/java/com/example/fixmatch/repository/ProyectoFotoRepository.java
@@ -1,0 +1,7 @@
+package com.example.fixmatch.repository;
+
+import com.example.fixmatch.entity.ProyectoFoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProyectoFotoRepository extends JpaRepository<ProyectoFoto, Long> {
+}

--- a/src/main/java/com/example/fixmatch/repository/ProyectoRepository.java
+++ b/src/main/java/com/example/fixmatch/repository/ProyectoRepository.java
@@ -1,0 +1,7 @@
+package com.example.fixmatch.repository;
+
+import com.example.fixmatch.entity.Proyecto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProyectoRepository extends JpaRepository<Proyecto, Long> {
+}

--- a/src/main/java/com/example/fixmatch/repository/SolicitudFotoRepository.java
+++ b/src/main/java/com/example/fixmatch/repository/SolicitudFotoRepository.java
@@ -1,0 +1,7 @@
+package com.example.fixmatch.repository;
+
+import com.example.fixmatch.entity.SolicitudFoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SolicitudFotoRepository extends JpaRepository<SolicitudFoto, Long> {
+}

--- a/src/main/java/com/example/fixmatch/repository/SolicitudRepository.java
+++ b/src/main/java/com/example/fixmatch/repository/SolicitudRepository.java
@@ -1,0 +1,7 @@
+package com.example.fixmatch.repository;
+
+import com.example.fixmatch.entity.Solicitud;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SolicitudRepository extends JpaRepository<Solicitud, Long> {
+}

--- a/src/main/java/com/example/fixmatch/service/ProyectoService.java
+++ b/src/main/java/com/example/fixmatch/service/ProyectoService.java
@@ -1,0 +1,48 @@
+package com.example.fixmatch.service;
+
+import com.example.fixmatch.dto.ProyectoRequest;
+import com.example.fixmatch.entity.Proyecto;
+import com.example.fixmatch.entity.ProyectoFoto;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.repository.ProyectoFotoRepository;
+import com.example.fixmatch.repository.ProyectoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ProyectoService {
+    private final ProyectoRepository proyectoRepository;
+    private final ProyectoFotoRepository fotoRepository;
+
+    public Proyecto create(ProyectoRequest request, User user) {
+        Proyecto p = new Proyecto();
+        p.setNombre(request.getNombre());
+        p.setDescripcion(request.getDescripcion());
+        p.setFecha(LocalDate.parse(request.getFecha()));
+        p.setUsuario(user);
+        return proyectoRepository.save(p);
+    }
+
+    public void addFoto(Long proyectoId, MultipartFile file) throws IOException {
+        Proyecto p = proyectoRepository.findById(proyectoId).orElseThrow();
+        String dirPath = "uploads/proyectos";
+        File dir = new File(dirPath);
+        dir.mkdirs();
+        String filename = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        File dest = new File(dir, filename);
+        file.transferTo(dest);
+        ProyectoFoto foto = new ProyectoFoto();
+        foto.setProyecto(p);
+        foto.setUrl(dest.getPath());
+        foto.setFechaSubida(LocalDateTime.now());
+        fotoRepository.save(foto);
+    }
+}

--- a/src/main/java/com/example/fixmatch/service/SolicitudService.java
+++ b/src/main/java/com/example/fixmatch/service/SolicitudService.java
@@ -1,0 +1,48 @@
+package com.example.fixmatch.service;
+
+import com.example.fixmatch.dto.SolicitudRequest;
+import com.example.fixmatch.entity.Solicitud;
+import com.example.fixmatch.entity.SolicitudFoto;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.repository.SolicitudFotoRepository;
+import com.example.fixmatch.repository.SolicitudRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class SolicitudService {
+    private final SolicitudRepository solicitudRepository;
+    private final SolicitudFotoRepository fotoRepository;
+
+    public Solicitud create(SolicitudRequest request, User user) {
+        Solicitud s = new Solicitud();
+        s.setEspecialidad(request.getEspecialidad());
+        s.setNombreSolicitud(request.getNombreSolicitud());
+        s.setDescripcion(request.getDescripcion());
+        s.setFechaCreacion(LocalDateTime.now());
+        s.setUsuario(user);
+        return solicitudRepository.save(s);
+    }
+
+    public void addFoto(Long solicitudId, MultipartFile file) throws IOException {
+        Solicitud s = solicitudRepository.findById(solicitudId).orElseThrow();
+        String dirPath = "uploads/solicitudes";
+        File dir = new File(dirPath);
+        dir.mkdirs();
+        String filename = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        File dest = new File(dir, filename);
+        file.transferTo(dest);
+        SolicitudFoto foto = new SolicitudFoto();
+        foto.setSolicitud(s);
+        foto.setUrl(dest.getPath());
+        foto.setFechaSubida(LocalDateTime.now());
+        fotoRepository.save(foto);
+    }
+}

--- a/src/main/java/com/example/fixmatch/service/UserService.java
+++ b/src/main/java/com/example/fixmatch/service/UserService.java
@@ -21,8 +21,14 @@ public class UserService {
         User user = new User();
         user.setName(request.getName());
         user.setEmail(request.getEmail());
-        user.setPassword(passwordEncoder.encode(request.getPassword()));
-        user.setRole(Optional.ofNullable(request.getRole()).orElse(Role.CLIENT));
+        user.setPassword(request.getPassword());
+        user.setRole(request.getRole());
+        return registerUser(user);
+    }
+
+    public User registerUser(User user) {
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+        user.setRole(Optional.ofNullable(user.getRole()).orElse(Role.CLIENT));
         return userRepository.save(user);
     }
 


### PR DESCRIPTION
## Summary
- extend `User` entity to include phone, location and services
- register new users via `/api/usuarios`
- create job requests and attach photos
- create projects and attach photos
- configure security to allow new registration endpoint

## Testing
- `./mvnw -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685c27b0ae608330b1bf85153a561eca