### PR TITLE
Add public jobs endpoint

### DIFF
--- a/src/main/java/com/example/fixmatch/config/SecurityConfig.java
+++ b/src/main/java/com/example/fixmatch/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
             .cors(cors -> {})
             .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/auth/**", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll()
+                .requestMatchers("/auth/**", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/api/trabajos").permitAll()
                 .anyRequest().authenticated())
             .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/com/example/fixmatch/controller/PublicJobController.java
+++ b/src/main/java/com/example/fixmatch/controller/PublicJobController.java
@@ -1,0 +1,38 @@
+package com.example.fixmatch.controller;
+
+import com.example.fixmatch.dto.JobResponse;
+import com.example.fixmatch.entity.Job;
+import com.example.fixmatch.service.JobService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/trabajos")
+@RequiredArgsConstructor
+public class PublicJobController {
+
+    private final JobService jobService;
+
+    @GetMapping
+    public ResponseEntity<List<JobResponse>> list() {
+        List<JobResponse> jobs = jobService.listAll().stream().map(this::toResponse).collect(Collectors.toList());
+        return ResponseEntity.ok(jobs);
+    }
+
+    private JobResponse toResponse(Job job) {
+        JobResponse response = new JobResponse();
+        response.setId(job.getId());
+        response.setTitle(job.getCategory());
+        response.setLocation(job.getLocation());
+        response.setDistance("0 km");
+        response.setDescription(job.getDescription());
+        response.setImages(job.getImages());
+        return response;
+    }
+}

--- a/src/main/java/com/example/fixmatch/dto/JobResponse.java
+++ b/src/main/java/com/example/fixmatch/dto/JobResponse.java
@@ -1,0 +1,15 @@
+package com.example.fixmatch.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class JobResponse {
+    private Long id;
+    private String title;
+    private String location;
+    private String distance;
+    private String description;
+    private List<String> images;
+}


### PR DESCRIPTION
## Summary
- add `JobResponse` DTO for frontend swipe data
- create `PublicJobController` exposing `GET /api/trabajos`
- allow unauthenticated access to `/api/trabajos`

## Testing
- `mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/...)*

------
https://chatgpt.com/codex/tasks/task_e_685c29f854cc8330a14ede58ff1eff49