### PR TITLE
Implement chat and message endpoints

### DIFF
--- a/src/main/java/com/example/fixmatch/controller/ChatController.java
+++ b/src/main/java/com/example/fixmatch/controller/ChatController.java
@@ -1,0 +1,50 @@
+package com.example.fixmatch.controller;
+
+import com.example.fixmatch.dto.ChatDto;
+import com.example.fixmatch.dto.ChatUserDto;
+import com.example.fixmatch.entity.Chat;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.service.ChatService;
+import com.example.fixmatch.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/chats")
+@RequiredArgsConstructor
+public class ChatController {
+    private final ChatService chatService;
+    private final UserService userService;
+
+    @GetMapping
+    public ResponseEntity<List<ChatDto>> list(Principal principal) {
+        User user = userService.findByEmail(principal.getName()).orElseThrow();
+        List<ChatDto> chats = chatService.findByUser(user).stream().map(c -> {
+            ChatDto dto = new ChatDto();
+            dto.setId(c.getId());
+            User other = c.getUser1().equals(user) ? c.getUser2() : c.getUser1();
+            dto.setUser(new ChatUserDto(other.getId(), other.getName()));
+            return dto;
+        }).collect(Collectors.toList());
+        return ResponseEntity.ok(chats);
+    }
+
+    @GetMapping("/{chatId}")
+    public ResponseEntity<ChatUserDto> get(@PathVariable Long chatId, Principal principal) {
+        User current = userService.findByEmail(principal.getName()).orElseThrow();
+        Chat chat = chatService.findById(chatId);
+        User other = chat.getUser1().equals(current) ? chat.getUser2() : chat.getUser1();
+        return ResponseEntity.ok(new ChatUserDto(other.getId(), other.getName()));
+    }
+
+    @DeleteMapping("/{chatId}")
+    public ResponseEntity<Void> delete(@PathVariable Long chatId) {
+        chatService.delete(chatId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/fixmatch/controller/MessageController.java
+++ b/src/main/java/com/example/fixmatch/controller/MessageController.java
@@ -1,36 +1,61 @@
 package com.example.fixmatch.controller;
 
 import com.example.fixmatch.dto.MessageRequest;
+import com.example.fixmatch.dto.MessageDto;
+import com.example.fixmatch.entity.Chat;
 import com.example.fixmatch.entity.Message;
 import com.example.fixmatch.entity.User;
+import com.example.fixmatch.service.ChatService;
 import com.example.fixmatch.service.MessageService;
 import com.example.fixmatch.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
-import java.util.List;
 
 @RestController
-@RequestMapping("/messages")
+@RequestMapping("/api/messages")
 @RequiredArgsConstructor
 public class MessageController {
 
     private final MessageService messageService;
     private final UserService userService;
+    private final ChatService chatService;
 
     @PostMapping
-    public ResponseEntity<Message> send(@RequestBody MessageRequest request, Principal principal) {
+    public ResponseEntity<MessageDto> send(@RequestBody MessageRequest request, Principal principal) {
         User sender = userService.findByEmail(principal.getName()).orElseThrow();
-        User receiver = userService.findById(request.getReceiverId()).orElseThrow();
-        return ResponseEntity.ok(messageService.send(request, sender, receiver));
+        User receiver;
+        if (request.getChatId() != null) {
+            Chat chat = chatService.findById(request.getChatId());
+            receiver = chat.getUser1().equals(sender) ? chat.getUser2() : chat.getUser1();
+        } else {
+            receiver = userService.findById(request.getReceiverId()).orElseThrow();
+        }
+        Message message = messageService.send(request, sender, receiver);
+        MessageDto dto = toDto(message);
+        return ResponseEntity.ok(dto);
     }
 
-    @GetMapping("/{userId}")
-    public ResponseEntity<List<Message>> chat(@PathVariable Long userId, Principal principal) {
-        User sender = userService.findByEmail(principal.getName()).orElseThrow();
-        User receiver = userService.findById(userId).orElseThrow();
-        return ResponseEntity.ok(messageService.getChat(sender, receiver));
+    @GetMapping
+    public ResponseEntity<Page<MessageDto>> messages(@RequestParam Long chatId, Pageable pageable, Principal principal) {
+        chatService.findById(chatId); // ensure exists
+        Chat chat = chatService.findById(chatId);
+        Page<MessageDto> page = messageService.getMessages(chat, pageable)
+                .map(this::toDto);
+        return ResponseEntity.ok(page);
+    }
+
+    private MessageDto toDto(Message message) {
+        MessageDto dto = new MessageDto();
+        dto.setId(message.getId());
+        dto.setChatId(message.getChat().getId());
+        dto.setSenderId(message.getSender().getId());
+        dto.setContent(message.getContent());
+        dto.setTimestamp(message.getTimestamp());
+        return dto;
     }
 }

--- a/src/main/java/com/example/fixmatch/dto/ChatDto.java
+++ b/src/main/java/com/example/fixmatch/dto/ChatDto.java
@@ -1,0 +1,9 @@
+package com.example.fixmatch.dto;
+
+import lombok.Data;
+
+@Data
+public class ChatDto {
+    private Long id;
+    private ChatUserDto user;
+}

--- a/src/main/java/com/example/fixmatch/dto/ChatUserDto.java
+++ b/src/main/java/com/example/fixmatch/dto/ChatUserDto.java
@@ -1,0 +1,11 @@
+package com.example.fixmatch.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ChatUserDto {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/com/example/fixmatch/dto/MessageDto.java
+++ b/src/main/java/com/example/fixmatch/dto/MessageDto.java
@@ -1,0 +1,14 @@
+package com.example.fixmatch.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class MessageDto {
+    private Long id;
+    private Long chatId;
+    private Long senderId;
+    private String content;
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/com/example/fixmatch/dto/MessageRequest.java
+++ b/src/main/java/com/example/fixmatch/dto/MessageRequest.java
@@ -4,6 +4,8 @@ import lombok.Data;
 
 @Data
 public class MessageRequest {
+    private Long chatId;
     private Long receiverId;
-    private String content;
+    private String text;
+    private String file;
 }

--- a/src/main/java/com/example/fixmatch/entity/Chat.java
+++ b/src/main/java/com/example/fixmatch/entity/Chat.java
@@ -2,20 +2,17 @@ package com.example.fixmatch.entity;
 
 import jakarta.persistence.*;
 import lombok.Data;
-import java.time.LocalDateTime;
 
 @Data
 @Entity
-public class Message {
+public class Chat {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @ManyToOne
-    private User sender;
+    private User user1;
+
     @ManyToOne
-    private User receiver;
-    @ManyToOne
-    private Chat chat;
-    private String content;
-    private LocalDateTime timestamp;
+    private User user2;
 }

--- a/src/main/java/com/example/fixmatch/repository/ChatRepository.java
+++ b/src/main/java/com/example/fixmatch/repository/ChatRepository.java
@@ -1,0 +1,14 @@
+package com.example.fixmatch.repository;
+
+import com.example.fixmatch.entity.Chat;
+import com.example.fixmatch.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatRepository extends JpaRepository<Chat, Long> {
+    List<Chat> findByUser1OrUser2(User user1, User user2);
+    Optional<Chat> findByUser1AndUser2(User user1, User user2);
+    Optional<Chat> findByUser2AndUser1(User user1, User user2); // for opposite order
+}

--- a/src/main/java/com/example/fixmatch/repository/MessageRepository.java
+++ b/src/main/java/com/example/fixmatch/repository/MessageRepository.java
@@ -1,11 +1,16 @@
 package com.example.fixmatch.repository;
 
+import com.example.fixmatch.entity.Chat;
 import com.example.fixmatch.entity.Message;
 import com.example.fixmatch.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
     List<Message> findBySenderAndReceiver(User sender, User receiver);
+    List<Message> findByChat(Chat chat);
+    Page<Message> findByChat(Chat chat, Pageable pageable);
 }

--- a/src/main/java/com/example/fixmatch/service/ChatService.java
+++ b/src/main/java/com/example/fixmatch/service/ChatService.java
@@ -1,0 +1,38 @@
+package com.example.fixmatch.service;
+
+import com.example.fixmatch.entity.Chat;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.repository.ChatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+    private final ChatRepository chatRepository;
+
+    public Chat getOrCreateChat(User user1, User user2) {
+        return chatRepository.findByUser1AndUser2(user1, user2)
+                .or(() -> chatRepository.findByUser2AndUser1(user1, user2))
+                .orElseGet(() -> {
+                    Chat chat = new Chat();
+                    chat.setUser1(user1);
+                    chat.setUser2(user2);
+                    return chatRepository.save(chat);
+                });
+    }
+
+    public List<Chat> findByUser(User user) {
+        return chatRepository.findByUser1OrUser2(user, user);
+    }
+
+    public Chat findById(Long id) {
+        return chatRepository.findById(id).orElseThrow();
+    }
+
+    public void delete(Long id) {
+        chatRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/example/fixmatch/service/MessageService.java
+++ b/src/main/java/com/example/fixmatch/service/MessageService.java
@@ -1,9 +1,12 @@
 package com.example.fixmatch.service;
 
 import com.example.fixmatch.dto.MessageRequest;
+import com.example.fixmatch.entity.Chat;
 import com.example.fixmatch.entity.Message;
 import com.example.fixmatch.entity.User;
 import com.example.fixmatch.repository.MessageRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,17 +17,30 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MessageService {
     private final MessageRepository messageRepository;
+    private final ChatService chatService;
 
     public Message send(MessageRequest request, User sender, User receiver) {
+        Chat chat;
+        if (request.getChatId() != null) {
+            chat = chatService.findById(request.getChatId());
+        } else {
+            chat = chatService.getOrCreateChat(sender, receiver);
+        }
         Message m = new Message();
         m.setSender(sender);
         m.setReceiver(receiver);
-        m.setContent(request.getContent());
+        m.setChat(chat);
+        m.setContent(request.getText() != null ? request.getText() : request.getFile());
         m.setTimestamp(LocalDateTime.now());
         return messageRepository.save(m);
     }
 
     public List<Message> getChat(User sender, User receiver) {
-        return messageRepository.findBySenderAndReceiver(sender, receiver);
+        Chat chat = chatService.getOrCreateChat(sender, receiver);
+        return messageRepository.findByChat(chat);
+    }
+
+    public Page<Message> getMessages(Chat chat, Pageable pageable) {
+        return messageRepository.findByChat(chat, pageable);
     }
 }


### PR DESCRIPTION
## Summary
- add Chat entity, repository and service
- update Message entity to link with Chat
- implement ChatController for listing, getting and deleting chats
- extend MessageController for paginated messages and sending messages using chat IDs
- add DTOs for chats and messages

## Testing
- `./mvnw test` *(fails: wget unable to fetch Maven binaries)*

------
https://chatgpt.com/codex/tasks/task_e_685c2b5e68c08330a20db90176e7b176