### PR TITLE
Add user profile management

### DIFF
--- a/src/main/java/com/example/fixmatch/controller/UserController.java
+++ b/src/main/java/com/example/fixmatch/controller/UserController.java
@@ -1,0 +1,30 @@
+package com.example.fixmatch.controller;
+
+import com.example.fixmatch.dto.UserProfileDto;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/profile")
+    public ResponseEntity<UserProfileDto> profile(Principal principal) {
+        User user = userService.findByEmail(principal.getName()).orElseThrow();
+        return ResponseEntity.ok(userService.toDto(user));
+    }
+
+    @PutMapping("/profile")
+    public ResponseEntity<UserProfileDto> update(@RequestBody UserProfileDto dto, Principal principal) {
+        User user = userService.findByEmail(principal.getName()).orElseThrow();
+        return ResponseEntity.ok(userService.updateProfile(user, dto));
+    }
+}

--- a/src/main/java/com/example/fixmatch/dto/EducationDto.java
+++ b/src/main/java/com/example/fixmatch/dto/EducationDto.java
@@ -1,0 +1,10 @@
+package com.example.fixmatch.dto;
+
+import lombok.Data;
+
+@Data
+public class EducationDto {
+    private String title;
+    private String institution;
+    private String period;
+}

--- a/src/main/java/com/example/fixmatch/dto/ResumeDto.java
+++ b/src/main/java/com/example/fixmatch/dto/ResumeDto.java
@@ -1,0 +1,11 @@
+package com.example.fixmatch.dto;
+
+import lombok.Data;
+
+@Data
+public class ResumeDto {
+    private String name;
+    private String url;
+    private Long size;
+    private String date;
+}

--- a/src/main/java/com/example/fixmatch/dto/UserProfileDto.java
+++ b/src/main/java/com/example/fixmatch/dto/UserProfileDto.java
@@ -1,0 +1,21 @@
+package com.example.fixmatch.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class UserProfileDto {
+    private String name;
+    private String dateOfBirth;
+    private String email;
+    private String countryCode;
+    private String phoneNumber;
+    private String location;
+    private String profileImage;
+    private Double rating;
+    private Integer projects;
+    private String aboutMe;
+    private List<EducationDto> education;
+    private ResumeDto resume;
+}

--- a/src/main/java/com/example/fixmatch/entity/Education.java
+++ b/src/main/java/com/example/fixmatch/entity/Education.java
@@ -1,0 +1,19 @@
+package com.example.fixmatch.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+public class Education {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String institution;
+    private String period;
+
+    @ManyToOne
+    private User user;
+}

--- a/src/main/java/com/example/fixmatch/entity/Resume.java
+++ b/src/main/java/com/example/fixmatch/entity/Resume.java
@@ -1,0 +1,22 @@
+package com.example.fixmatch.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Entity
+public class Resume {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String url;
+    private Long size;
+    private LocalDate date;
+
+    @OneToOne
+    private User user;
+}

--- a/src/main/java/com/example/fixmatch/entity/User.java
+++ b/src/main/java/com/example/fixmatch/entity/User.java
@@ -17,4 +17,22 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Role role;
     private Double reputation;
+
+    private String dateOfBirth;
+    private String countryCode;
+    private String phoneNumber;
+    private String location;
+    private String profileImage;
+    private Double rating;
+    private Integer projects;
+    private String aboutMe;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private java.util.List<Education> education;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Resume resume;
+
+    @OneToMany(mappedBy = "uploadedBy")
+    private java.util.List<Certificate> certificates;
 }

--- a/src/main/java/com/example/fixmatch/repository/EducationRepository.java
+++ b/src/main/java/com/example/fixmatch/repository/EducationRepository.java
@@ -1,0 +1,7 @@
+package com.example.fixmatch.repository;
+
+import com.example.fixmatch.entity.Education;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EducationRepository extends JpaRepository<Education, Long> {
+}

--- a/src/main/java/com/example/fixmatch/repository/ResumeRepository.java
+++ b/src/main/java/com/example/fixmatch/repository/ResumeRepository.java
@@ -1,0 +1,7 @@
+package com.example.fixmatch.repository;
+
+import com.example.fixmatch.entity.Resume;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResumeRepository extends JpaRepository<Resume, Long> {
+}

--- a/src/main/java/com/example/fixmatch/service/UserService.java
+++ b/src/main/java/com/example/fixmatch/service/UserService.java
@@ -1,10 +1,16 @@
 package com.example.fixmatch.service;
 
-import com.example.fixmatch.dto.LoginRequest;
 import com.example.fixmatch.dto.RegisterRequest;
+import com.example.fixmatch.dto.UserProfileDto;
+import com.example.fixmatch.dto.EducationDto;
+import com.example.fixmatch.dto.ResumeDto;
 import com.example.fixmatch.entity.Role;
 import com.example.fixmatch.entity.User;
+import com.example.fixmatch.entity.Education;
+import com.example.fixmatch.entity.Resume;
 import com.example.fixmatch.repository.UserRepository;
+import com.example.fixmatch.repository.EducationRepository;
+import com.example.fixmatch.repository.ResumeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -16,6 +22,8 @@ import java.util.Optional;
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final EducationRepository educationRepository;
+    private final ResumeRepository resumeRepository;
 
     public User register(RegisterRequest request) {
         User user = new User();
@@ -32,5 +40,88 @@ public class UserService {
 
     public Optional<User> findById(Long id) {
         return userRepository.findById(id);
+    }
+
+    public UserProfileDto toDto(User user) {
+        UserProfileDto dto = new UserProfileDto();
+        dto.setName(user.getName());
+        dto.setDateOfBirth(user.getDateOfBirth());
+        dto.setEmail(user.getEmail());
+        dto.setCountryCode(user.getCountryCode());
+        dto.setPhoneNumber(user.getPhoneNumber());
+        dto.setLocation(user.getLocation());
+        dto.setProfileImage(user.getProfileImage());
+        dto.setRating(user.getRating());
+        dto.setProjects(user.getProjects());
+        dto.setAboutMe(user.getAboutMe());
+        if (user.getEducation() != null) {
+            java.util.List<EducationDto> eds = new java.util.ArrayList<>();
+            for (Education e : user.getEducation()) {
+                EducationDto ed = new EducationDto();
+                ed.setTitle(e.getTitle());
+                ed.setInstitution(e.getInstitution());
+                ed.setPeriod(e.getPeriod());
+                eds.add(ed);
+            }
+            dto.setEducation(eds);
+        }
+        if (user.getResume() != null) {
+            ResumeDto r = new ResumeDto();
+            r.setName(user.getResume().getName());
+            r.setUrl(user.getResume().getUrl());
+            r.setSize(user.getResume().getSize());
+            if (user.getResume().getDate() != null)
+                r.setDate(user.getResume().getDate().toString());
+            dto.setResume(r);
+        }
+        return dto;
+    }
+
+    public UserProfileDto updateProfile(User user, UserProfileDto dto) {
+        user.setName(dto.getName());
+        user.setDateOfBirth(dto.getDateOfBirth());
+        user.setCountryCode(dto.getCountryCode());
+        user.setPhoneNumber(dto.getPhoneNumber());
+        user.setLocation(dto.getLocation());
+        user.setProfileImage(dto.getProfileImage());
+        user.setRating(dto.getRating());
+        user.setProjects(dto.getProjects());
+        user.setAboutMe(dto.getAboutMe());
+
+        // update education
+        if (dto.getEducation() != null) {
+            if (user.getEducation() != null) {
+                educationRepository.deleteAll(user.getEducation());
+                user.getEducation().clear();
+            } else {
+                user.setEducation(new java.util.ArrayList<>());
+            }
+            for (EducationDto ed : dto.getEducation()) {
+                Education e = new Education();
+                e.setTitle(ed.getTitle());
+                e.setInstitution(ed.getInstitution());
+                e.setPeriod(ed.getPeriod());
+                e.setUser(user);
+                user.getEducation().add(e);
+            }
+        }
+
+        // update resume
+        if (dto.getResume() != null) {
+            Resume r = user.getResume();
+            if (r == null) {
+                r = new Resume();
+                r.setUser(user);
+            }
+            r.setName(dto.getResume().getName());
+            r.setUrl(dto.getResume().getUrl());
+            r.setSize(dto.getResume().getSize());
+            if (dto.getResume().getDate() != null)
+                r.setDate(java.time.LocalDate.parse(dto.getResume().getDate()));
+            user.setResume(r);
+        }
+
+        userRepository.save(user);
+        return toDto(user);
     }
 }


### PR DESCRIPTION
## Summary
- extend `User` with profile fields
- create `Education` and `Resume` entities
- add DTOs for profile, resume and education
- implement profile retrieval and update in `UserService`
- expose `/api/user/profile` GET and PUT via `UserController`
- add repositories for education and resume

## Testing
- `mvnw -q test` *(fails: repo.maven.apache.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685c2d13ba2c833081e842b1206873d3