### PR TITLE
Implement login endpoint returning user info

### DIFF
--- a/src/main/java/com/example/fixmatch/controller/AuthController.java
+++ b/src/main/java/com/example/fixmatch/controller/AuthController.java
@@ -1,13 +1,16 @@
 package com.example.fixmatch.controller;
 
 import com.example.fixmatch.dto.*;
+import com.example.fixmatch.entity.Role;
 import com.example.fixmatch.entity.User;
 import com.example.fixmatch.security.JwtTokenProvider;
 import com.example.fixmatch.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -30,10 +33,17 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody LoginRequest request) {
-        Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword()));
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-        String token = tokenProvider.generateToken(request.getEmail());
-        return ResponseEntity.ok(new AuthResponse(token));
+        try {
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword()));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            User user = userService.findByEmail(request.getEmail()).orElseThrow();
+            String token = tokenProvider.generateToken(request.getEmail());
+            String tipo = user.getRole() == Role.CLIENT ? "cliente" : "especialista";
+            return ResponseEntity.ok(new LoginResponse(user.getId(), tipo, token));
+        } catch (AuthenticationException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(java.util.Map.of("message", "Credenciales inválidas"));
+        }
     }
 }

--- a/src/main/java/com/example/fixmatch/dto/LoginResponse.java
+++ b/src/main/java/com/example/fixmatch/dto/LoginResponse.java
@@ -1,0 +1,12 @@
+package com.example.fixmatch.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class LoginResponse {
+    private Long id;
+    private String tipoUsuario;
+    private String token;
+}


### PR DESCRIPTION
## Summary
- add `LoginResponse` DTO to expose user id and type along with the JWT
- update `AuthController` login to send back `LoginResponse` and handle authentication failures

## Testing
- `./mvnw -q test` *(fails: wget Failed to fetch)*

------
https://chatgpt.com/codex/tasks/task_e_685c2f09da008330b4861c5af6af5bd6