### PR TITLE
Implement task endpoints

### DIFF
--- a/src/main/java/com/example/fixmatch/controller/TaskController.java
+++ b/src/main/java/com/example/fixmatch/controller/TaskController.java
@@ -1,0 +1,27 @@
+package com.example.fixmatch.controller;
+
+import com.example.fixmatch.entity.Task;
+import com.example.fixmatch.service.TaskService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/tasks")
+@RequiredArgsConstructor
+public class TaskController {
+
+    private final TaskService taskService;
+
+    @GetMapping("/scheduled")
+    public ResponseEntity<List<Task>> scheduled(@RequestParam Long userId) {
+        return ResponseEntity.ok(taskService.findTasksByUserAndStatus(userId, "En espera"));
+    }
+
+    @GetMapping("/completed")
+    public ResponseEntity<List<Task>> completed(@RequestParam Long userId) {
+        return ResponseEntity.ok(taskService.findTasksByUserAndStatus(userId, "Completada"));
+    }
+}

--- a/src/main/java/com/example/fixmatch/dto/RegisterRequest.java
+++ b/src/main/java/com/example/fixmatch/dto/RegisterRequest.java
@@ -9,4 +9,5 @@ public class RegisterRequest {
     private String email;
     private String password;
     private Role role;
+    private String avatar;
 }

--- a/src/main/java/com/example/fixmatch/entity/Task.java
+++ b/src/main/java/com/example/fixmatch/entity/Task.java
@@ -1,0 +1,17 @@
+package com.example.fixmatch.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+public class Task {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    private String description;
+    private String status;
+    @ManyToOne
+    private User user;
+}

--- a/src/main/java/com/example/fixmatch/entity/User.java
+++ b/src/main/java/com/example/fixmatch/entity/User.java
@@ -16,5 +16,6 @@ public class User {
     private String password;
     @Enumerated(EnumType.STRING)
     private Role role;
+    private String avatar;
     private Double reputation;
 }

--- a/src/main/java/com/example/fixmatch/repository/TaskRepository.java
+++ b/src/main/java/com/example/fixmatch/repository/TaskRepository.java
@@ -1,0 +1,11 @@
+package com.example.fixmatch.repository;
+
+import com.example.fixmatch.entity.Task;
+import com.example.fixmatch.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+    List<Task> findByUserAndStatus(User user, String status);
+}

--- a/src/main/java/com/example/fixmatch/service/TaskService.java
+++ b/src/main/java/com/example/fixmatch/service/TaskService.java
@@ -1,0 +1,23 @@
+package com.example.fixmatch.service;
+
+import com.example.fixmatch.entity.Task;
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.repository.TaskRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TaskService {
+    private final TaskRepository taskRepository;
+    private final UserService userService;
+
+    public List<Task> findTasksByUserAndStatus(Long userId, String status) {
+        return userService.findById(userId)
+                .map(user -> taskRepository.findByUserAndStatus(user, status))
+                .orElse(Collections.emptyList());
+    }
+}

--- a/src/main/java/com/example/fixmatch/service/UserService.java
+++ b/src/main/java/com/example/fixmatch/service/UserService.java
@@ -23,6 +23,7 @@ public class UserService {
         user.setEmail(request.getEmail());
         user.setPassword(passwordEncoder.encode(request.getPassword()));
         user.setRole(Optional.ofNullable(request.getRole()).orElse(Role.CLIENT));
+        user.setAvatar(request.getAvatar());
         return userRepository.save(user);
     }
 


### PR DESCRIPTION
## Summary
- add avatar field on `User` and accept avatar during registration
- introduce `Task` entity and persistence layer
- create `TaskService` and `TaskController` with scheduled and completed endpoints

## Testing
- `./mvnw -q test` *(fails: Failed to fetch Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685c2fbc2b38833099a7cb762098164d