### PR TITLE
Add user entity with fields and controller

### DIFF
--- a/src/main/java/com/example/fixmatch/controller/UsuarioController.java
+++ b/src/main/java/com/example/fixmatch/controller/UsuarioController.java
@@ -1,0 +1,45 @@
+package com.example.fixmatch.controller;
+
+import com.example.fixmatch.entity.User;
+import com.example.fixmatch.repository.UserRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/usuarios")
+public class UsuarioController {
+
+    private final UserRepository userRepository;
+
+    public UsuarioController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @PostMapping
+    public ResponseEntity<User> createUser(@RequestBody User user) {
+        User saved = userRepository.save(user);
+        return ResponseEntity.ok(saved);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<User> updateUser(@PathVariable Long id, @RequestBody User updated) {
+        return userRepository.findById(id)
+                .map(user -> {
+                    user.setNombre(updated.getNombre());
+                    user.setEmail(updated.getEmail());
+                    user.setTelefono(updated.getTelefono());
+                    user.setUbicacion(updated.getUbicacion());
+                    user.setServicios(updated.getServicios());
+                    User saved = userRepository.save(user);
+                    return ResponseEntity.ok(saved);
+                })
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @GetMapping
+    public List<User> allUsers() {
+        return userRepository.findAll();
+    }
+}

--- a/src/main/java/com/example/fixmatch/entity/User.java
+++ b/src/main/java/com/example/fixmatch/entity/User.java
@@ -1,0 +1,24 @@
+package com.example.fixmatch.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.util.List;
+
+@Data
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nombre;
+    private String email;
+    private String telefono;
+    private String ubicacion;
+
+    @ElementCollection
+    @CollectionTable(name = "user_servicios", joinColumns = @JoinColumn(name = "user_id"))
+    @Column(name = "servicio")
+    private List<String> servicios;
+}

--- a/src/main/java/com/example/fixmatch/repository/UserRepository.java
+++ b/src/main/java/com/example/fixmatch/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.example.fixmatch.repository;
+
+import com.example.fixmatch.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
## Summary
- create `User` entity with telefono, ubicacion and servicios fields
- add `UserRepository`
- implement basic `UsuarioController`

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c36ab597c8330bb697c24661ab52b